### PR TITLE
Create capyschool github readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,37 @@
+## Capy School
+
+Welcome to the Capy School organization. If you are arriving from our website or exploring our GitHub presence, this profile is a quick orientation.
+
+### What you will find here
+- **Tickets repository**: Central place to track ideas, tasks, bugs, and roadmap items.
+  - Visit: [capy-school/tickets](https://github.com/capy-school/tickets)
+- **Learning resources**: Repositories and notes designed for language learners with a strong linguistic focus (phonology, morphology, syntax, semantics, and pragmatics).
+
+### For language learners (with a linguistic focus)
+- **Evidence-based approach**: We emphasize form–meaning mappings, input-rich exposure, and spaced retrieval.
+- **Linguistic scaffolding**:
+  - Phonology: Sound systems, minimal pairs, and pronunciation practice aligned with IPA.
+  - Morphology: Word formation patterns and affixation to build vocabulary depth.
+  - Syntax: Sentence patterns and constructions that generalize across examples.
+  - Semantics & Pragmatics: Meaning nuances, register, and context-appropriate usage.
+- **Actionable materials**: Expect datasets, graded input, and tasks that foreground structure without losing communicative relevance.
+
+### Getting started
+1. Browse open items or propose new ones in the Tickets repository: [capy-school/tickets](https://github.com/capy-school/tickets).
+2. Explore repositories labeled `learning`, `curriculum`, or `linguistics` for structured materials.
+3. Visit our site for the live experience and updates: [www.capyschool.com](https://www.capyschool.com).
+
+### Contributing
+- Use the Tickets repository to report issues, request features, or discuss pedagogy.
+- When proposing resources, please include:
+  - Target proficiency level
+  - Linguistic focus area (e.g., phonology, morphology, syntax)
+  - Learning objectives and minimal examples
+
+### Links
+- **Organization home**: [github.com/capy-school](https://github.com/capy-school)
+- **Tickets**: [capy-school/tickets](https://github.com/capy-school/tickets)
+- **Website**: [www.capyschool.com](https://www.capyschool.com)
+
+---
+Thank you for helping build a learner-first, linguistics-informed language education platform.

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,20 +7,6 @@ Welcome to the Capy School organization. If you are arriving from our website or
   - Visit: [capy-school/tickets](https://github.com/capy-school/tickets)
 - **Learning resources**: Repositories and notes designed for language learners with a strong linguistic focus (phonology, morphology, syntax, semantics, and pragmatics).
 
-### For language learners (with a linguistic focus)
-- **Evidence-based approach**: We emphasize form–meaning mappings, input-rich exposure, and spaced retrieval.
-- **Linguistic scaffolding**:
-  - Phonology: Sound systems, minimal pairs, and pronunciation practice aligned with IPA.
-  - Morphology: Word formation patterns and affixation to build vocabulary depth.
-  - Syntax: Sentence patterns and constructions that generalize across examples.
-  - Semantics & Pragmatics: Meaning nuances, register, and context-appropriate usage.
-- **Actionable materials**: Expect datasets, graded input, and tasks that foreground structure without losing communicative relevance.
-
-### Getting started
-1. Browse open items or propose new ones in the Tickets repository: [capy-school/tickets](https://github.com/capy-school/tickets).
-2. Explore repositories labeled `learning`, `curriculum`, or `linguistics` for structured materials.
-3. Visit our site for the live experience and updates: [www.capyschool.com](https://www.capyschool.com).
-
 ### Contributing
 - Use the Tickets repository to report issues, request features, or discuss pedagogy.
 - When proposing resources, please include:


### PR DESCRIPTION
Add `profile/README.md` to guide visitors to Capy School's resources, including the tickets repository and linguistic-focused learning materials.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b18083d-d601-49f9-885b-38dc83a0a493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b18083d-d601-49f9-885b-38dc83a0a493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

